### PR TITLE
release: v1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ temp-test-config/
 
 # GitGuardian cache
 .cache_ggshield
+test-results/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huangjunsen0406/xiaozhi-mcphub",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MCPHub enhanced with Xiaozhi AI platform integration - 为小智AI平台优化的MCP工具桥接系统",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `package.json` to **1.1.1** for patch release.
- Ships commits already on main since v1.1.0: MCPB zip-slip hardening (#29), VitePress docs + screenshots, CI/lint/boot test fixes.

## Changelog highlights (v1.0.0… will be auto-generated on tag; since v1.1.0)
### Fixes / Security
- MCPB extract: reject zip entries with `..` (CWE-22 zip-slip)
- Lint/test: changelogService escapes, boot mock for owner backfill, ESM import in mcpb test
- CI: VitePress Pages install (`--ignore-workspace`, pnpm action-setup)

### Docs
- Replace Mintlify with VitePress; rewrite user docs for 1.1.0; console screenshots
- Release notes workflow bilingual template

## Release plan
After merge to `main`:
1. Tag `v1.1.1` on merge commit
2. Build → `huangjunsen/xiaozhi-mcphub:1.1.1` + `:latest`
3. GitHub Release auto changelog from `v1.1.0..v1.1.1`

## Test plan
- [x] CI green on main tip before branch
- [ ] CI on this PR
- [ ] Tag workflows Build + Release success