### PR TITLE
release: v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huangjunsen0406/xiaozhi-mcphub",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "MCPHub enhanced with Xiaozhi AI platform integration - 为小智AI平台优化的MCP工具桥接系统",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump version to **1.1.2**.
- Ships #32 Xiaozhi hardening already on main: remove client compat layer, reconnect backpressure/jitter, `/health` xiaozhi summary, endpoint runtime diagnostics UI.

## Release plan
After merge:
1. Tag `v1.1.2` on merge commit of this PR
2. Docker `huangjunsen/xiaozhi-mcphub:1.1.2` + `:latest`
3. GitHub Release changelog from `v1.1.1..v1.1.2` (and broader history via git log)

## Test plan
- [ ] CI on this PR
- [ ] Tag Build + Release workflows