### PR TITLE
fix: recover v1.0.3 servers/endpoints on 1.1.x upgrade (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@
 docker pull huangjunsen/xiaozhi-mcphub:latest
 
 # Run (adjust DB URL and password to your environment)
+# Use DB_URL (1.1.x). Legacy DATABASE_URL from v1.0.3 is still accepted as a fallback.
 docker run -d \
   --name xiaozhi-mcphub \
   -p 3000:3000 \
-  -e DATABASE_URL="postgres://xiaozhi:xiaozhi123456@localhost:5432/xiaozhi_mcphub" \
+  -e DB_URL="postgres://xiaozhi:xiaozhi123456@host.docker.internal:5432/xiaozhi_mcphub" \
   -e SMART_ROUTING_ENABLED="false" \
   -v $(pwd)/data:/app/data \
   huangjunsen/xiaozhi-mcphub:latest
@@ -77,9 +78,25 @@ docker compose logs -f mcphub
 
 Key variables (edit in compose if needed):
 
-- `DATABASE_URL`: `postgres://xiaozhi:<password>@db:5432/xiaozhi_mcphub`
+- `DB_URL`: `postgres://xiaozhi:<password>@db:5432/xiaozhi_mcphub` (legacy `DATABASE_URL` still works)
 - `SMART_ROUTING_ENABLED`: Enable/disable smart routing (default "false").
 - Optional: `BASE_PATH`, `JWT_SECRET`, `OPENAI_API_KEY`, etc. (see above)
+
+### Upgrading from v1.0.3
+
+If you already jumped to 1.1.x and servers disappeared, **do not wipe the Postgres volume**.
+1.1.x+ will detect the legacy `mcp_servers` table (when still present) and copy any missing
+rows into the new `servers` table on startup. Prefer renaming the env var:
+
+```bash
+# before (v1.0.3)
+DATABASE_URL=postgres://xiaozhi:…@db:5432/xiaozhi_mcphub
+
+# after (1.1.x) — same credentials / same volume
+DB_URL=postgres://xiaozhi:…@db:5432/xiaozhi_mcphub
+```
+
+Details: [documents/docs/configuration/upgrade-from-v103.md](documents/docs/configuration/upgrade-from-v103.md).
 
 ### Method 3: Local development
 
@@ -94,7 +111,7 @@ pnpm install
 docker compose up -d db
 
 # Set database connection (or write to .env)
-export DATABASE_URL="postgres://xiaozhi:xiaozhi123456@localhost:5432/xiaozhi_mcphub"
+export DB_URL="postgres://xiaozhi:xiaozhi123456@localhost:5432/xiaozhi_mcphub"
 
 # Start both backend (:3000) and frontend (Vite :5173)
 pnpm dev

--- a/README.zh.md
+++ b/README.zh.md
@@ -43,10 +43,11 @@
 docker pull huangjunsen/xiaozhi-mcphub:latest
 
 # 运行（请按需修改数据库地址与口令）
+# 1.1.x 使用 DB_URL；v1.0.3 的 DATABASE_URL 仍可作为兼容回退
 docker run -d \
   --name xiaozhi-mcphub \
   -p 3000:3000 \
-  -e DATABASE_URL="postgres://xiaozhi:xiaozhi123456@localhost:5432/xiaozhi_mcphub" \
+  -e DB_URL="postgres://xiaozhi:xiaozhi123456@host.docker.internal:5432/xiaozhi_mcphub" \
   -e SMART_ROUTING_ENABLED="false" \
   -v $(pwd)/data:/app/data \
   huangjunsen/xiaozhi-mcphub:latest
@@ -76,9 +77,25 @@ docker compose logs -f mcphub
 
 关键变量（可在 compose 中修改）
 
-- `DATABASE_URL`: `postgres://xiaozhi:密码@db:5432/xiaozhi_mcphub`
+- `DB_URL`: `postgres://xiaozhi:密码@db:5432/xiaozhi_mcphub`（旧名 `DATABASE_URL` 仍兼容）
 - `SMART_ROUTING_ENABLED`: 开启/关闭智能路由（默认 "false"）
 - 可选：`BASE_PATH`、`JWT_SECRET`、`OPENAI_API_KEY` 等（见上）
+
+### 从 v1.0.3 升级
+
+如果已经升到 1.1.x 且 servers 看起来丢了，**不要清 Postgres volume**。
+只要库里还留着旧表 `mcp_servers`，新版本启动时会把缺失的行补偿拷进 `servers`。
+推荐把环境变量改成：
+
+```bash
+# 旧（v1.0.3）
+DATABASE_URL=postgres://xiaozhi:…@db:5432/xiaozhi_mcphub
+
+# 新（1.1.x）— 同一套账号 / 同一 volume
+DB_URL=postgres://xiaozhi:…@db:5432/xiaozhi_mcphub
+```
+
+详见 [documents/docs/configuration/upgrade-from-v103.md](documents/docs/configuration/upgrade-from-v103.md)。
 
 ### 方式三：本地开发
 
@@ -93,7 +110,7 @@ pnpm install
 docker compose up -d db
 
 # 设置数据库连接（或写入 .env）
-export DATABASE_URL="postgres://xiaozhi:xiaozhi123456@localhost:5432/xiaozhi_mcphub"
+export DB_URL="postgres://xiaozhi:xiaozhi123456@localhost:5432/xiaozhi_mcphub"
 
 # 同时启动后端（:3000）与前端（Vite :5173）
 pnpm dev

--- a/documents/docs/.vitepress/config.mts
+++ b/documents/docs/.vitepress/config.mts
@@ -16,6 +16,7 @@ export default defineConfig({
         items: [
           { text: 'Docker 部署', link: '/configuration/docker-setup' },
           { text: '环境变量', link: '/configuration/environment-variables' },
+          { text: '从 v1.0.3 升级', link: '/configuration/upgrade-from-v103' },
           { text: 'MCP 配置', link: '/configuration/mcp-settings' },
           { text: 'Nginx', link: '/configuration/nginx' },
           { text: '小智接入', link: '/configuration/xiaozhi' },
@@ -54,6 +55,7 @@ export default defineConfig({
           items: [
             { text: 'Docker 部署', link: '/configuration/docker-setup' },
             { text: '环境变量', link: '/configuration/environment-variables' },
+            { text: '从 v1.0.3 升级', link: '/configuration/upgrade-from-v103' },
             { text: 'MCP 配置', link: '/configuration/mcp-settings' },
             { text: 'Nginx', link: '/configuration/nginx' },
             { text: '小智接入', link: '/configuration/xiaozhi' },

--- a/documents/docs/configuration/docker-setup.md
+++ b/documents/docs/configuration/docker-setup.md
@@ -96,3 +96,5 @@ curl -s http://localhost:3000/health
 | 登录后空白 | 检查 `BASE_PATH`、反向代理与静态资源路径 |
 | 拉镜像 401 | Docker Hub 登录或镜像名是否为 `huangjunsen/xiaozhi-mcphub` |
 | 关于-更新检查失败 | 出站访问 GitHub；或设 `DISABLE_UPDATE_CHECK=true` |
+| 从 1.0.3 升级后 servers 为空 | 见 [从 v1.0.3 升级](/configuration/upgrade-from-v103)；确认未删 `pgdata`，日志是否有 `mcp_servers` 补偿迁移 |
+| `ECONNREFUSED 127.0.0.1:5432` | 容器内未配置有效 `DB_URL`/`DATABASE_URL`，或误把主机写成 localhost |

--- a/documents/docs/configuration/environment-variables.md
+++ b/documents/docs/configuration/environment-variables.md
@@ -1,7 +1,8 @@
 # 环境变量
 
 xiaozhi-mcphub **1.1.0** 通过环境变量与（可选）`mcp_settings.json` / 数据库系统配置共同生效。  
-与旧版文档的重要差异：数据库连接使用 **`DB_URL`**（不是 `DATABASE_URL`）。
+与旧版文档的重要差异：数据库连接使用 **`DB_URL`**。  
+从 **v1.0.3** 升级时旧名 **`DATABASE_URL` 仍可读**（会打 deprecation 警告）；请尽快改成 `DB_URL`。详见 [从 v1.0.3 升级](/configuration/upgrade-from-v103)。
 
 ## 核心
 
@@ -21,7 +22,8 @@ xiaozhi-mcphub **1.1.0** 通过环境变量与（可选）`mcp_settings.json` / 
 | 变量 | 说明 |
 |------|------|
 | `DB_URL` | PostgreSQL 连接串。配置后通常启用数据库模式；**小智端点等依赖 DB** |
-| `USE_DB` | 可选，显式开关 DB 模式（一般随 `DB_URL` 自动判断） |
+| `DATABASE_URL` | **兼容旧版**：与 `DB_URL` 同义；仅当 `DB_URL` 未设时生效 |
+| `USE_DB` | 可选，显式开关 DB 模式（一般随 `DB_URL` / `DATABASE_URL` 自动判断） |
 
 ```bash
 DB_URL=postgres://xiaozhi:密码@127.0.0.1:5432/xiaozhi_mcphub

--- a/documents/docs/configuration/upgrade-from-v103.md
+++ b/documents/docs/configuration/upgrade-from-v103.md
@@ -1,0 +1,106 @@
+# 从 v1.0.3 升级到 1.1.x
+
+适用于已经在跑 **xiaozhi-mcphub 1.0.3**（或同代「始终连 PostgreSQL」版本），要升到 **1.1.x** 的用户。  
+也覆盖：**已经升到 1.1.0–1.1.2 后发现 servers / 端点「丢了」**，但 Postgres volume 还在的场景。
+
+## 发生了什么
+
+| 项目 | v1.0.3 | 1.1.x |
+|------|--------|-------|
+| 环境变量 | `DATABASE_URL` | **`DB_URL`**（现已兼容读取旧名） |
+| MCP 服务器表 | `mcp_servers`（`name` 主键） | `servers`（uuid + `owner+name` 唯一） |
+| 小智端点表 | `xiaozhi_endpoints` | 同名（多了 `owner`） |
+| 无库时 | 仍会连默认 localhost Postgres | 可回退到 JSON 文件模式 |
+
+1.1.x 早期若只换了镜像、仍只配 `DATABASE_URL`，应用会当成「没配库」走进文件模式，界面只剩镜像内置示例服务器，并可能在日志里生成新的 admin 密码。  
+即便连上了同一 Postgres，TypeORM `synchronize` 也会**新建空的 `servers` 表**，不会自动把 `mcp_servers` 拷过去——旧数据其实还在旧表里。
+
+## 升级 / 找回步骤（推荐）
+
+1. **备份 Postgres volume**（`pgdata`），不要 `docker compose down -v`。
+2. 确认 compose / 运行参数指向**同一个**数据库。
+3. 把环境变量改成（或同时保留旧名亦可）：
+
+```yaml
+environment:
+  DB_URL: "postgres://xiaozhi:你的密码@db:5432/xiaozhi_mcphub"
+  # 可选：显式 USE_DB: "true"
+```
+
+容器内主机名用 compose 服务名（如 `db`），不要用 `127.0.0.1`（那是容器自己）。
+
+4. 拉起带补偿迁移的版本（含本修复的 1.1.x+）：
+
+```bash
+docker compose pull   # 或指定新 tag
+docker compose up -d
+docker compose logs -f mcphub
+```
+
+5. 日志中应出现类似：
+
+```text
+[legacy-schema] Found legacy mcp_servers with N row(s); copying any missing servers…
+  - migrated server: …
+[legacy-schema] mcp_servers migration done: copied=…, skipped=…
+```
+
+6. 登录控制台核对 Servers / 小智端点。  
+   - 已存在同名 `(owner, name)` 的新行会被 **skip**（不覆盖你后来手工重建的配置）。  
+   - 旧表 `mcp_servers` **保留作备份**，不会自动 DROP。
+
+## 已经升到 1.1.2、数据「丢了」怎么办
+
+只要 **Postgres 里还看得到 `mcp_servers`**，升到带本修复的版本再启动一次即可补偿：
+
+```sql
+-- 在库里确认旧表还在
+SELECT COUNT(*) FROM mcp_servers;
+SELECT COUNT(*) FROM servers;
+SELECT COUNT(*) FROM xiaozhi_endpoints;
+```
+
+- `mcp_servers` 有数据、`servers` 为空或明显偏少 → 启动后会把缺失行拷进 `servers`。  
+- 小智端点表名未变；连对库后应直接可见，并会把空 `owner` 回填为 `admin`。  
+
+### Admin 密码会不会丢？要不要迁？
+
+**不用单独迁 admin 密码。** v1.0.3 的账号就在同一 Postgres 的 **`users`** 表里（bcrypt 哈希，表名未改）。
+
+| 情况 | 登录用什么 |
+|------|------------|
+| 连回**原来的** `pgdata` / 同一库 | **你升级前自己设过的 admin 密码**（或 v1.0.3 默认 `admin123`，若从未改过） |
+| 1.1.x 曾因没配 `DB_URL` 走进文件模式，日志打印了随机密码 | 那是写在**空的 JSON 用户列表**里的一次性账号；**不会**写回覆盖 Postgres 里的旧 admin |
+| 生产环境空库首次启动 | 才会生成随机密码并打日志（`admin123` 仅 development） |
+
+启动成功连上旧库时日志类似：
+
+```text
+[legacy-schema] Reusing N existing user(s) from the database (including admin). Keep the password you set before the upgrade…
+User store already has N account(s); reusing existing admin credentials (not regenerating password)
+```
+
+可在库里自检：
+
+```sql
+SELECT username, is_admin, length(password) AS hash_len, created_at
+FROM users
+ORDER BY created_at;
+```
+
+`admin` 行还在且 `hash_len` 正常（bcrypt 一般 60）→ 用**旧密码**登录即可，无需 reset。  
+只有 `users` 也空了（例如误删 volume）才需要用日志里的新密码或 `ADMIN_PASSWORD` 重建。
+
+若 `mcp_servers` 和 volume 都没了，应用无法凭空恢复，只能从外部备份还原。
+
+## 兼容说明
+
+- **`DATABASE_URL`**：启动时仍可读，并打一次 deprecation 警告；请尽快改成 `DB_URL`。  
+- **空 DB URL + 智能路由 embedding**：不再默默连 `127.0.0.1:5432`，会跳过或明确报错。  
+- **JSON 文件 → DB**：仅在新库 `users` 为空时从 `mcp_settings.json` 导入；**不能**替代 `mcp_servers` 补偿（那是另一条路径）。
+
+## 相关文件
+
+- `src/config/dbEnv.ts` — `DB_URL` / `DATABASE_URL` 解析  
+- `src/utils/legacySchemaMigration.ts` — `mcp_servers` → `servers` 等  
+- `src/utils/migration.ts` — 启动时调用补偿 + owner 回填  

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@huangjunsen0406/xiaozhi-mcphub",
-  "version": "1.1.2",
-  "description": "MCPHub enhanced with Xiaozhi AI platform integration - 为小智AI平台优化的MCP工具桥接系统",
+  "version": "1.1.3",
+  "description": "MCPHub enhanced with Xiaozhi AI platform integration - \u4e3a\u5c0f\u667aAI\u5e73\u53f0\u4f18\u5316\u7684MCP\u5de5\u5177\u6865\u63a5\u7cfb\u7edf",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -3,6 +3,7 @@ import { genericOAuth } from 'better-auth/plugins';
 import { PostgresDialect } from 'kysely';
 import { Pool } from 'pg';
 import defaultConfig, { loadSettings } from './config/index.js';
+import { getDatabaseUrlFromEnv } from './config/dbEnv.js';
 import { resolveBetterAuthRuntimeConfig } from './services/betterAuthConfig.js';
 import { resolveInstallBaseUrl } from './utils/installBaseUrl.js';
 import { getCachedSystemConfig, isDatabaseModeEnabled } from './utils/systemConfigCache.js';
@@ -94,9 +95,9 @@ const baseURL = resolveBaseURL(
   runtimeConfig.basePath,
 );
 
-const databaseUrl = process.env.DB_URL;
+const databaseUrl = getDatabaseUrlFromEnv();
 if (!databaseUrl) {
-  throw new Error('DB_URL is required for Better Auth PostgreSQL storage.');
+  throw new Error('DB_URL (or legacy DATABASE_URL) is required for Better Auth PostgreSQL storage.');
 }
 
 const pool = new Pool({

--- a/src/config/dbEnv.test.ts
+++ b/src/config/dbEnv.test.ts
@@ -1,0 +1,70 @@
+import { jest } from '@jest/globals';
+
+describe('dbEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.DB_URL;
+    delete process.env.DATABASE_URL;
+    delete process.env.USE_DB;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('prefers DB_URL over legacy DATABASE_URL', async () => {
+    process.env.DB_URL = 'postgres://new/db';
+    process.env.DATABASE_URL = 'postgres://legacy/db';
+
+    const { getDatabaseUrlFromEnv } = await import('./dbEnv.js');
+    expect(getDatabaseUrlFromEnv()).toBe('postgres://new/db');
+  });
+
+  it('falls back to DATABASE_URL and warns once', async () => {
+    process.env.DATABASE_URL = '  postgres://legacy/db  ';
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const {
+      getDatabaseUrlFromEnv,
+      resetDatabaseUrlDeprecationWarningForTests,
+    } = await import('./dbEnv.js');
+    resetDatabaseUrlDeprecationWarningForTests();
+
+    expect(getDatabaseUrlFromEnv()).toBe('postgres://legacy/db');
+    expect(getDatabaseUrlFromEnv()).toBe('postgres://legacy/db');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('DATABASE_URL is deprecated');
+
+    warn.mockRestore();
+  });
+
+  it('treats blank values as unset', async () => {
+    process.env.DB_URL = '   ';
+    process.env.DATABASE_URL = '';
+
+    const { getDatabaseUrlFromEnv, isDatabaseModeEnabled } = await import('./dbEnv.js');
+    expect(getDatabaseUrlFromEnv()).toBeUndefined();
+    expect(isDatabaseModeEnabled()).toBe(false);
+  });
+
+  it('enables DB mode from either URL unless USE_DB overrides', async () => {
+    process.env.DATABASE_URL = 'postgres://legacy/db';
+    let mod = await import('./dbEnv.js');
+    expect(mod.isDatabaseModeEnabled()).toBe(true);
+
+    jest.resetModules();
+    process.env = { ...originalEnv, USE_DB: 'false', DATABASE_URL: 'postgres://legacy/db' };
+    mod = await import('./dbEnv.js');
+    expect(mod.isDatabaseModeEnabled()).toBe(false);
+
+    jest.resetModules();
+    process.env = { ...originalEnv, USE_DB: 'true' };
+    delete process.env.DB_URL;
+    delete process.env.DATABASE_URL;
+    mod = await import('./dbEnv.js');
+    expect(mod.isDatabaseModeEnabled()).toBe(true);
+  });
+});

--- a/src/config/dbEnv.ts
+++ b/src/config/dbEnv.ts
@@ -1,0 +1,58 @@
+/**
+ * Database environment helpers.
+ *
+ * v1.0.x used DATABASE_URL; v1.1+ standardizes on DB_URL.
+ * Keep a read-only fallback so Docker Compose upgrades do not silently
+ * fall back to JSON file mode and drop servers / Xiaozhi endpoints.
+ */
+
+let databaseUrlDeprecationWarned = false;
+
+/**
+ * Resolve the effective PostgreSQL connection string from the environment.
+ * Prefer DB_URL; fall back to legacy DATABASE_URL with a one-time warning.
+ */
+export function getDatabaseUrlFromEnv(): string | undefined {
+  const current = trimEnv(process.env.DB_URL);
+  if (current) {
+    return current;
+  }
+
+  const legacy = trimEnv(process.env.DATABASE_URL);
+  if (legacy) {
+    if (!databaseUrlDeprecationWarned) {
+      databaseUrlDeprecationWarned = true;
+      console.warn(
+        '[DEPRECATED] DATABASE_URL is deprecated since 1.1.x; use DB_URL instead. ' +
+          'Accepting DATABASE_URL for backward compatibility with v1.0.3 installs.',
+      );
+    }
+    return legacy;
+  }
+
+  return undefined;
+}
+
+/**
+ * Whether the process should run in database-backed mode.
+ * USE_DB wins when set; otherwise any resolved DB URL enables DB mode.
+ */
+export function isDatabaseModeEnabled(): boolean {
+  if (process.env.USE_DB !== undefined) {
+    return process.env.USE_DB === 'true';
+  }
+  return Boolean(getDatabaseUrlFromEnv());
+}
+
+/** Test-only: reset one-time deprecation warning state. */
+export function resetDatabaseUrlDeprecationWarningForTests(): void {
+  databaseUrlDeprecationWarned = false;
+}
+
+function trimEnv(value: string | undefined): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/src/controllers/healthController.ts
+++ b/src/controllers/healthController.ts
@@ -1,11 +1,8 @@
 import { Request, Response } from 'express';
+import { isDatabaseModeEnabled } from '../config/dbEnv.js';
 import { getDatabaseHealth } from '../db/connection.js';
 import { getServerConnectionStats } from '../services/mcpService.js';
 import { xiaozhiEndpointService } from '../services/xiaozhiEndpointService.js';
-
-const isDatabaseModeEnabled = (): boolean => {
-  return process.env.USE_DB !== undefined ? process.env.USE_DB === 'true' : !!process.env.DB_URL;
-};
 
 /**
  * Health check endpoint.

--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from 'node:util';
 import { Request, Response } from 'express';
+import { getDatabaseUrlFromEnv } from '../config/dbEnv.js';
 import {
   ApiResponse,
   AddServerRequest,
@@ -314,17 +315,23 @@ export const getAllSettings = async (req: Request, res: Response): Promise<void>
     const systemConfig = systemConfigResult || {};
 
     // Ensure smart routing config has DB URL set if environment variable is present
-    const dbUrlEnv = process.env.DB_URL || '';
+    // Prefer DB_URL; accept legacy DATABASE_URL so upgraded v1.0.3 installs still work.
+    const dbUrlEnv = getDatabaseUrlFromEnv() || '';
+    const dbUrlPlaceholder = process.env.DB_URL
+      ? '${DB_URL}'
+      : process.env.DATABASE_URL
+        ? '${DATABASE_URL}'
+        : '';
     if (!systemConfig.smartRouting) {
       systemConfig.smartRouting = {
         enabled: false,
-        dbUrl: dbUrlEnv ? '${DB_URL}' : '',
+        dbUrl: dbUrlEnv ? dbUrlPlaceholder : '',
         openaiApiBaseUrl: '',
         openaiApiKey: '',
         openaiApiEmbeddingModel: '',
       };
     } else if (!systemConfig.smartRouting.dbUrl) {
-      systemConfig.smartRouting.dbUrl = dbUrlEnv ? '${DB_URL}' : '';
+      systemConfig.smartRouting.dbUrl = dbUrlEnv ? dbUrlPlaceholder : '';
     }
 
     if (!systemConfig.toolResultCompression) {
@@ -1812,7 +1819,7 @@ export const updateSystemConfig = async (req: Request, res: Response): Promise<v
         // If enabling Smart Routing, validate required fields
         if (smartRouting.enabled) {
           const currentDbUrl =
-            process.env.DB_URL || smartRouting.dbUrl || systemConfig.smartRouting.dbUrl;
+            getDatabaseUrlFromEnv() || smartRouting.dbUrl || systemConfig.smartRouting.dbUrl;
 
           if (!currentDbUrl) {
             res.status(400).json({

--- a/src/dao/DaoFactory.ts
+++ b/src/dao/DaoFactory.ts
@@ -169,9 +169,9 @@ export function getDaoFactory(): DaoFactory {
  * This is synchronous and should be called during app initialization
  */
 export async function initializeDaoFactory(): Promise<void> {
-  // If USE_DB is explicitly set, use its value; otherwise, auto-detect based on DB_URL presence
-  const useDatabase =
-    process.env.USE_DB !== undefined ? process.env.USE_DB === 'true' : !!process.env.DB_URL;
+  // USE_DB wins when set; otherwise auto-detect from DB_URL / legacy DATABASE_URL
+  const { isDatabaseModeEnabled } = await import('../config/dbEnv.js');
+  const useDatabase = isDatabaseModeEnabled();
   if (useDatabase) {
     console.log('Using database-backed DAO implementations');
     // Dynamic import to avoid circular dependencies

--- a/src/db/connection.test.ts
+++ b/src/db/connection.test.ts
@@ -115,6 +115,27 @@ describe('database connection recovery', () => {
     expect(dataSource.initialize).toHaveBeenCalledTimes(1);
   });
 
+  it('refuses to connect when no DB URL is configured instead of defaulting to localhost', async () => {
+    getSmartRoutingConfigMock.mockResolvedValueOnce({ dbUrl: '' });
+    const previousDbUrl = process.env.DB_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    delete process.env.DB_URL;
+    delete process.env.DATABASE_URL;
+
+    await expect(updateDataSourceConfig()).rejects.toThrow(/Database URL is not configured/);
+
+    if (previousDbUrl === undefined) {
+      delete process.env.DB_URL;
+    } else {
+      process.env.DB_URL = previousDbUrl;
+    }
+    if (previousDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    }
+  });
+
   it('cleans up an initialized connection when post-initialization setup fails', async () => {
     jest.useFakeTimers();
     const dataSource = await updateDataSourceConfig();

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -49,9 +49,25 @@ const createRequiredExtensions = async (dataSource: DataSource): Promise<void> =
   }
 };
 
-// Get database URL from smart routing config or fallback to environment variable
+// Get database URL from smart routing config, env (DB_URL / legacy DATABASE_URL),
+// and fail loudly instead of letting `pg` default to 127.0.0.1:5432.
 const getDatabaseUrl = async (): Promise<string> => {
-  return (await getSmartRoutingConfig()).dbUrl;
+  const fromConfig = ((await getSmartRoutingConfig()).dbUrl || '').trim();
+  if (fromConfig) {
+    return fromConfig;
+  }
+
+  // Direct env fallback in case smartRouting settings are not hydrated yet.
+  const { getDatabaseUrlFromEnv } = await import('../config/dbEnv.js');
+  const fromEnv = getDatabaseUrlFromEnv();
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  throw new Error(
+    'Database URL is not configured. Set DB_URL (or legacy DATABASE_URL for v1.0.3 upgrades). ' +
+      'Refusing to fall back to localhost:5432.',
+  );
 };
 
 const ensureEmbeddingColumnIsVector = async (dataSource: DataSource): Promise<void> => {

--- a/src/db/entities/SystemConfig.ts
+++ b/src/db/entities/SystemConfig.ts
@@ -15,16 +15,17 @@ export class SystemConfig {
   @Column({ type: 'simple-json', nullable: true })
   install?: Record<string, any>;
 
-  @Column({ type: 'simple-json', nullable: true })
+  // Explicit snake_case names preserve v1.0.3 system_config columns under synchronize.
+  @Column({ type: 'simple-json', name: 'smart_routing', nullable: true })
   smartRouting?: Record<string, any>;
 
   @Column({ type: 'simple-json', nullable: true })
   toolResultCompression?: Record<string, any>;
 
-  @Column({ type: 'simple-json', nullable: true })
+  @Column({ type: 'simple-json', name: 'mcp_router', nullable: true })
   mcpRouter?: Record<string, any>;
 
-  @Column({ type: 'simple-json', nullable: true })
+  @Column({ type: 'simple-json', name: 'modelscope', nullable: true })
   modelscope?: Record<string, any>;
 
   @Column({ type: 'simple-json', nullable: true })

--- a/src/db/entities/User.ts
+++ b/src/db/entities/User.ts
@@ -20,7 +20,8 @@ export class User {
   @Column({ type: 'varchar', length: 255 })
   password: string;
 
-  @Column({ type: 'boolean', default: false })
+  // Keep explicit snake_case column name so v1.0.3 databases (is_admin) keep working.
+  @Column({ type: 'boolean', default: false, name: 'is_admin' })
   isAdmin: boolean;
 
   @Column({ type: 'varchar', length: 255, nullable: true, unique: true })

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,10 +168,9 @@ async function boot() {
   try {
     setupGlobalProxyFetch();
 
-    // Check if database mode is enabled
-    // If USE_DB is explicitly set, use its value; otherwise, auto-detect based on DB_URL presence
-    const useDatabase =
-      process.env.USE_DB !== undefined ? process.env.USE_DB === 'true' : !!process.env.DB_URL;
+    // Check if database mode is enabled (DB_URL, legacy DATABASE_URL, or explicit USE_DB)
+    const { isDatabaseModeEnabled } = await import('./config/dbEnv.js');
+    const useDatabase = isDatabaseModeEnabled();
     if (useDatabase) {
       console.log('Database mode enabled, initializing...');
       const dbInitialized = await initializeDatabaseMode();

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -154,29 +154,47 @@ export const initializeDefaultUser = async (): Promise<void> => {
   const userDao = getUserDao();
   const users = await userDao.findAll();
 
-  if (users.length === 0) {
-    const createDefaultAdmin = async (password: string): Promise<void> => {
-      await userDao.createWithHashedPassword('admin', password, true);
-      console.log('Default admin user created');
-    };
-
-    const adminPasswordFromEnv = process.env.ADMIN_PASSWORD;
-    if (adminPasswordFromEnv) {
-      await createDefaultAdmin(adminPasswordFromEnv);
-      return;
-    }
-
-    if (process.env.NODE_ENV === 'development') {
-      await createDefaultAdmin('admin123');
-      console.log('Using development admin password: admin123');
-      return;
-    }
-
-    const generatedPassword = generateRandomPassword();
-    await createDefaultAdmin(generatedPassword);
-    console.log('========================================');
-    console.log('  Generated admin password: ' + generatedPassword);
-    console.log('  Please change this password after first login.');
-    console.log('========================================');
+  if (users.length > 0) {
+    // Existing installs (including v1.0.3 Postgres `users` rows) keep their
+    // hashed passwords as-is. Never overwrite admin when the table is non-empty.
+    const hasAdmin = users.some((user) => user.username === 'admin');
+    console.log(
+      `User store already has ${users.length} account(s)` +
+        (hasAdmin
+          ? '; reusing existing admin credentials (not regenerating password)'
+          : ' (no admin username — not auto-creating one because the store is non-empty)'),
+    );
+    return;
   }
+
+  const createDefaultAdmin = async (password: string): Promise<void> => {
+    await userDao.createWithHashedPassword('admin', password, true);
+    console.log('Default admin user created');
+  };
+
+  const adminPasswordFromEnv = process.env.ADMIN_PASSWORD;
+  if (adminPasswordFromEnv) {
+    await createDefaultAdmin(adminPasswordFromEnv);
+    return;
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    await createDefaultAdmin('admin123');
+    console.log('Using development admin password: admin123');
+    return;
+  }
+
+  const generatedPassword = generateRandomPassword();
+  await createDefaultAdmin(generatedPassword);
+  console.log('========================================');
+  console.log('  Generated admin password: ' + generatedPassword);
+  console.log('  Please change this password after first login.');
+  console.log(
+    '  Note: this only runs on an empty user store. If you upgraded from v1.0.3',
+  );
+  console.log(
+    '  and expected your old password, reconnect DB_URL to the original Postgres',
+  );
+  console.log('  volume — the legacy admin hash lives in the users table.');
+  console.log('========================================');
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -254,8 +254,8 @@ export class AppServer {
     }
 
     // Close database connection if in database mode
-    const useDatabase =
-      process.env.USE_DB !== undefined ? process.env.USE_DB === 'true' : !!process.env.DB_URL;
+    const { isDatabaseModeEnabled } = await import('./config/dbEnv.js');
+    const useDatabase = isDatabaseModeEnabled();
     if (useDatabase) {
       try {
         const { closeDatabase } = await import('./db/connection.js');

--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -1060,6 +1060,14 @@ export const saveToolsAsVectorEmbeddings = async (
       return;
     }
 
+    if (!smartRoutingConfig.dbUrl) {
+      console.warn(
+        '[EMBED_SYNC_ERROR] Skipping tool embedding sync because DB URL is not configured',
+        { serverName },
+      );
+      return;
+    }
+
     // Ensure database is initialized before starting
     if (!isDatabaseConnected()) {
       console.log('Database not initialized, initializing...');
@@ -1536,7 +1544,8 @@ export const getAllVectorizedTools = async (
 export const removeServerToolEmbeddings = async (serverName: string): Promise<void> => {
   try {
     const smartRoutingConfig = await getSmartRoutingConfig();
-    if (!smartRoutingConfig.dbUrl && !process.env.DB_URL) {
+    const { getDatabaseUrlFromEnv } = await import('../config/dbEnv.js');
+    if (!smartRoutingConfig.dbUrl && !getDatabaseUrlFromEnv()) {
       console.warn('Skipping embedding cleanup because DB URL is not configured', {
         serverName,
       });
@@ -1625,7 +1634,14 @@ export const syncAllServerToolsEmbeddings = async (): Promise<void> => {
 async function checkDatabaseVectorDimensions(dimensionsNeeded: number): Promise<boolean> {
   try {
     // First check if database is initialized
-    if (!getAppDataSource().isInitialized) {
+    if (!isDatabaseConnected()) {
+      const smartRoutingConfig = await getSmartRoutingConfig();
+      if (!smartRoutingConfig.dbUrl) {
+        console.warn(
+          'Skipping vector dimension check because DB URL is not configured',
+        );
+        return false;
+      }
       console.info('Database not initialized, initializing...');
       await initializeDatabase();
     }

--- a/src/utils/legacySchemaMigration.test.ts
+++ b/src/utils/legacySchemaMigration.test.ts
@@ -1,0 +1,204 @@
+import { jest } from '@jest/globals';
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<any>;
+
+function createDataSourceMock(handler: QueryFn) {
+  const save = jest.fn(async (entity: any) => entity);
+  const create = jest.fn((data: any) => ({ ...data }));
+  const getOne = jest.fn(async () => null);
+  const andWhere = jest.fn(() => ({ getOne }));
+  const where = jest.fn(() => ({ andWhere }));
+  const createQueryBuilder = jest.fn(() => ({ where }));
+
+  return {
+    query: jest.fn(handler) as unknown as jest.MockedFunction<QueryFn>,
+    getRepository: jest.fn(() => ({
+      create,
+      save,
+      createQueryBuilder,
+    })),
+    _repo: { save, create, getOne, andWhere, where, createQueryBuilder },
+  };
+}
+
+describe('legacySchemaMigration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('copies mcp_servers rows into servers via repository when missing', async () => {
+    const dataSource = createDataSourceMock(async (sql: string) => {
+      const normalized = sql.replace(/\s+/g, ' ').toLowerCase();
+      if (normalized.includes('information_schema.tables') && normalized.includes('table_name')) {
+        // tableExists for mcp_servers / servers
+        return [{ exists: true }];
+      }
+      if (normalized.includes('from mcp_servers')) {
+        return [
+          {
+            name: 'fetch',
+            type: 'stdio',
+            url: null,
+            command: 'uvx',
+            args: '["mcp-server-fetch"]',
+            env: null,
+            headers: null,
+            enabled: true,
+            owner: null,
+            keep_alive_interval: 30,
+            tools: null,
+            prompts: null,
+            options: null,
+            openapi: null,
+            created_at: new Date('2024-01-01T00:00:00Z'),
+            updated_at: new Date('2024-01-02T00:00:00Z'),
+          },
+          {
+            name: 'playwright',
+            type: 'stdio',
+            command: 'npx',
+            args: '["@playwright/mcp@latest"]',
+            enabled: true,
+            owner: 'alice',
+            keep_alive_interval: null,
+            env: null,
+            headers: null,
+            tools: null,
+            prompts: null,
+            options: null,
+            openapi: null,
+            url: null,
+            created_at: null,
+            updated_at: null,
+          },
+        ];
+      }
+      if (normalized.includes('information_schema.columns')) {
+        return [{ exists: true }];
+      }
+      if (normalized.includes('count(*)')) {
+        return [{ count: 0 }];
+      }
+      return [];
+    });
+
+    // First existing lookup returns a hit for playwright only on second call via getOne
+    dataSource._repo.getOne
+      .mockResolvedValueOnce(null) // fetch → copy
+      .mockResolvedValueOnce({ id: 'existing' }); // playwright → skip
+
+    const { migrateMcpServersTable } = await import('./legacySchemaMigration.js');
+    const result = await migrateMcpServersTable(dataSource as any);
+
+    expect(result).toEqual({ serversCopied: 1, serversSkipped: 1 });
+    expect(dataSource._repo.save).toHaveBeenCalledTimes(1);
+    expect(dataSource._repo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'fetch',
+        command: 'uvx',
+        args: ['mcp-server-fetch'],
+        owner: 'admin',
+        visibility: 'private',
+        keepAliveInterval: 30,
+        enabled: true,
+      }),
+    );
+  });
+
+  it('is a no-op when mcp_servers table is absent', async () => {
+    const dataSource = createDataSourceMock(async (sql: string) => {
+      if (sql.includes('information_schema.tables')) {
+        return [{ exists: false }];
+      }
+      return [];
+    });
+
+    const { migrateMcpServersTable } = await import('./legacySchemaMigration.js');
+    const result = await migrateMcpServersTable(dataSource as any);
+    expect(result).toEqual({ serversCopied: 0, serversSkipped: 0 });
+    expect(dataSource.getRepository).not.toHaveBeenCalled();
+  });
+
+  it('runLegacySchemaMigrations backfills endpoint and group owners', async () => {
+    const dataSource = createDataSourceMock(async (sql: string, params?: unknown[]) => {
+      const normalized = sql.replace(/\s+/g, ' ').toLowerCase();
+      if (normalized.includes('information_schema.tables')) {
+        return [{ exists: true }];
+      }
+      if (normalized.includes('information_schema.columns')) {
+        // owner / is_admin / smart_routing present
+        return [{ exists: true }];
+      }
+      if (normalized.includes('from mcp_servers')) {
+        return [];
+      }
+      if (normalized.includes('count(*)') && normalized.includes('from users')) {
+        return [{ count: 1 }];
+      }
+      if (normalized.includes('from users') && normalized.includes('username')) {
+        return [{ '?column?': 1 }];
+      }
+      if (normalized.includes('count(*)') && normalized.includes('xiaozhi_endpoints')) {
+        return [{ count: 2 }];
+      }
+      if (normalized.includes('count(*)') && normalized.includes('groups')) {
+        return [{ count: 1 }];
+      }
+      if (normalized.startsWith('update ')) {
+        return { rowCount: params ? 1 : 0 };
+      }
+      return [];
+    });
+
+    const { runLegacySchemaMigrations } = await import('./legacySchemaMigration.js');
+    const summary = await runLegacySchemaMigrations(dataSource as any);
+
+    expect(summary.endpointOwnersBackfilled).toBe(2);
+    expect(summary.groupOwnersBackfilled).toBe(1);
+    expect(summary.serversCopied).toBe(0);
+    expect(summary.existingUserCount).toBe(1);
+    expect(summary.adminUserPresent).toBe(true);
+  });
+
+  it('alignUserAdminColumn renames camelCase leftover', async () => {
+    const dataSource = createDataSourceMock(async (sql: string) => {
+      const normalized = sql.replace(/\s+/g, ' ').toLowerCase();
+      if (normalized.includes('information_schema.tables')) {
+        return [{ exists: true }];
+      }
+      if (normalized.includes("column_name = $2") || normalized.includes('column_name')) {
+        // Sequence of checks: is_admin then isAdmin — inspect params
+        return [{ exists: false }];
+      }
+      return [];
+    });
+
+    // More precise columnExists responses via params
+    (dataSource.query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
+      const normalized = sql.replace(/\s+/g, ' ').toLowerCase();
+      if (normalized.includes('information_schema.tables')) {
+        return [{ exists: true }];
+      }
+      if (normalized.includes('information_schema.columns')) {
+        const col = params?.[1];
+        if (col === 'is_admin') return [{ exists: false }];
+        if (col === 'isAdmin') return [{ exists: true }];
+        return [{ exists: false }];
+      }
+      if (normalized.includes('rename column')) {
+        return [];
+      }
+      return [];
+    });
+
+    const { alignUserAdminColumn } = await import('./legacySchemaMigration.js');
+    const changed = await alignUserAdminColumn(dataSource as any);
+    expect(changed).toBe(true);
+    expect(
+      (dataSource.query as any).mock.calls.some((call: unknown[]) =>
+        String(call[0]).includes('RENAME COLUMN'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/utils/legacySchemaMigration.ts
+++ b/src/utils/legacySchemaMigration.ts
@@ -1,0 +1,466 @@
+import { DataSource } from 'typeorm';
+
+/** Legacy resources without an owner are attributed to the default admin account. */
+const LEGACY_OWNER = 'admin';
+
+/**
+ * One-shot schema upgrades for installs that started on xiaozhi-mcphub v1.0.x
+ * (notably 1.0.3) and jump to 1.1.x.
+ *
+ * Critical change: MCP server rows lived in `mcp_servers` (name PK). 1.1.x uses
+ * `servers` (uuid PK + unique (owner, name)). TypeORM synchronize creates the
+ * new empty table and never copies legacy rows, so upgraded users lose every
+ * server unless we move them here.
+ *
+ * Also normalizes a few shared tables that changed column naming / nullability
+ * between those releases.
+ */
+
+export type LegacySchemaMigrationResult = {
+  serversCopied: number;
+  serversSkipped: number;
+  endpointOwnersBackfilled: number;
+  groupOwnersBackfilled: number;
+  userAdminColumnAligned: boolean;
+  systemConfigColumnsAligned: boolean;
+  /** Existing rows in `users` after column alignment (0 means empty / new install). */
+  existingUserCount: number;
+  /** Whether an `admin` username row is present in `users`. */
+  adminUserPresent: boolean;
+};
+
+type LegacyMcpServerRow = {
+  name: string;
+  type: string | null;
+  url: string | null;
+  command: string | null;
+  args: string | null;
+  env: string | null;
+  headers: string | null;
+  enabled: boolean | null;
+  owner: string | null;
+  keep_alive_interval: number | null;
+  tools: string | null;
+  prompts: string | null;
+  options: string | null;
+  openapi: string | null;
+  created_at: Date | string | null;
+  updated_at: Date | string | null;
+};
+
+const tableExists = async (dataSource: DataSource, tableName: string): Promise<boolean> => {
+  const rows = await dataSource.query(
+    `
+    SELECT EXISTS (
+      SELECT FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = $1
+    ) AS exists
+    `,
+    [tableName],
+  );
+  return Boolean(rows?.[0]?.exists);
+};
+
+const columnExists = async (
+  dataSource: DataSource,
+  tableName: string,
+  columnName: string,
+): Promise<boolean> => {
+  const rows = await dataSource.query(
+    `
+    SELECT EXISTS (
+      SELECT FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = $1
+        AND column_name = $2
+    ) AS exists
+    `,
+    [tableName, columnName],
+  );
+  return Boolean(rows?.[0]?.exists);
+};
+
+const resolveOwner = (owner: string | null | undefined): string => {
+  if (owner === null || owner === undefined) {
+    return LEGACY_OWNER;
+  }
+  const trimmed = String(owner).trim();
+  return trimmed.length > 0 ? trimmed : LEGACY_OWNER;
+};
+
+const toTimestamp = (value: Date | string | null | undefined): Date | null => {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+/**
+ * Parse a legacy simple-json / json / simple-array cell into a JS value.
+ */
+const parseLegacyJson = <T>(value: unknown, fallback: T): T => {
+  if (value === null || value === undefined || value === '') {
+    return fallback;
+  }
+  if (typeof value === 'object') {
+    return value as T;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return fallback;
+    }
+    try {
+      return JSON.parse(trimmed) as T;
+    } catch {
+      // simple-array historically stored comma-separated values
+      return trimmed.split(',').map((part) => part.trim()).filter(Boolean) as T;
+    }
+  }
+  return fallback;
+};
+
+/**
+ * Copy `mcp_servers` → `servers` when the legacy table still has rows that are
+ * missing from the new table. Idempotent: rows already present for the same
+ * (owner, name) are skipped. Legacy table is left in place as a backup.
+ *
+ * Uses the TypeORM Server repository so column naming matches synchronize.
+ */
+export async function migrateMcpServersTable(
+  dataSource: DataSource,
+): Promise<Pick<LegacySchemaMigrationResult, 'serversCopied' | 'serversSkipped'>> {
+  const result = { serversCopied: 0, serversSkipped: 0 };
+
+  if (!(await tableExists(dataSource, 'mcp_servers'))) {
+    return result;
+  }
+  if (!(await tableExists(dataSource, 'servers'))) {
+    console.warn(
+      '[legacy-schema] mcp_servers found but servers table is missing; skipping server copy',
+    );
+    return result;
+  }
+
+  const legacyRows: LegacyMcpServerRow[] = await dataSource.query(
+    `SELECT * FROM mcp_servers ORDER BY created_at ASC NULLS LAST, name ASC`,
+  );
+
+  if (!legacyRows.length) {
+    console.log('[legacy-schema] mcp_servers is empty; nothing to copy');
+    return result;
+  }
+
+  // Recovery path for installs that already jumped to 1.1.x: the old table is
+  // often still present with the real server configs while `servers` is empty
+  // or only partially re-created. Copy any missing (owner, name) pairs.
+  console.log(
+    `[legacy-schema] Found legacy mcp_servers with ${legacyRows.length} row(s); ` +
+      'copying any missing servers into the 1.1.x `servers` table (idempotent recovery)…',
+  );
+
+  // Entity import is local to avoid pulling DAO/migration graphs at module load.
+  const serverModule = await import('../db/entities/Server.js');
+  const ServerEntity = serverModule.default ?? serverModule.Server;
+  const repository = dataSource.getRepository(ServerEntity);
+
+  for (const row of legacyRows) {
+    if (!row?.name) {
+      result.serversSkipped += 1;
+      continue;
+    }
+
+    const owner = resolveOwner(row.owner);
+    const existing = await repository
+      .createQueryBuilder('server')
+      .where('server.name = :name', { name: row.name })
+      .andWhere(
+        '(server.owner = :owner OR (:owner = :legacy AND (server.owner IS NULL OR server.owner = :empty)))',
+        { owner, legacy: LEGACY_OWNER, empty: '' },
+      )
+      .getOne();
+
+    if (existing) {
+      result.serversSkipped += 1;
+      continue;
+    }
+
+    const enabled = row.enabled === null || row.enabled === undefined ? true : Boolean(row.enabled);
+    const entity = repository.create({
+      name: row.name,
+      type: row.type ?? undefined,
+      url: row.url ?? undefined,
+      command: row.command ?? undefined,
+      args: parseLegacyJson<string[] | undefined>(row.args, undefined),
+      env: parseLegacyJson<Record<string, string> | undefined>(row.env, undefined),
+      headers: parseLegacyJson<Record<string, string> | undefined>(row.headers, undefined),
+      enabled,
+      owner,
+      visibility: 'private',
+      enableKeepAlive: false,
+      keepAliveInterval: row.keep_alive_interval ?? undefined,
+      tools: parseLegacyJson(row.tools, undefined),
+      prompts: parseLegacyJson(row.prompts, undefined),
+      options: parseLegacyJson(row.options, undefined),
+      openapi: parseLegacyJson(row.openapi, undefined),
+    });
+
+    // Preserve original timestamps when the driver/column allows assignment.
+    const createdAt = toTimestamp(row.created_at);
+    const updatedAt = toTimestamp(row.updated_at) ?? createdAt;
+    if (createdAt) {
+      entity.createdAt = createdAt;
+    }
+    if (updatedAt) {
+      entity.updatedAt = updatedAt;
+    }
+
+    await repository.save(entity);
+    result.serversCopied += 1;
+    console.log(`  - migrated server: ${row.name} (owner=${owner})`);
+  }
+
+  console.log(
+    `[legacy-schema] mcp_servers migration done: copied=${result.serversCopied}, skipped=${result.serversSkipped}`,
+  );
+  return result;
+}
+
+/**
+ * Attribute empty group owners to admin (groups table name is stable).
+ */
+export async function backfillGroupOwners(dataSource: DataSource): Promise<number> {
+  if (!(await tableExists(dataSource, 'groups'))) {
+    return 0;
+  }
+  if (!(await columnExists(dataSource, 'groups', 'owner'))) {
+    await dataSource.query(`ALTER TABLE groups ADD COLUMN IF NOT EXISTS owner character varying`);
+  }
+
+  const nullCountRows = await dataSource.query(
+    `
+    SELECT COUNT(*)::int AS count
+    FROM groups
+    WHERE owner IS NULL OR owner = ''
+    `,
+  );
+  const pending = Number(nullCountRows?.[0]?.count ?? 0);
+  if (pending === 0) {
+    return 0;
+  }
+
+  await dataSource.query(
+    `
+    UPDATE groups
+    SET owner = $1
+    WHERE owner IS NULL OR owner = ''
+    `,
+    [LEGACY_OWNER],
+  );
+  return pending;
+}
+
+/**
+ * v1.0.3 stored users.is_admin; some 1.1 builds briefly used "isAdmin".
+ * Prefer the snake_case column and copy data if a camelCase leftover exists.
+ */
+export async function alignUserAdminColumn(dataSource: DataSource): Promise<boolean> {
+  if (!(await tableExists(dataSource, 'users'))) {
+    return false;
+  }
+
+  const hasSnake = await columnExists(dataSource, 'users', 'is_admin');
+  const hasCamel = await columnExists(dataSource, 'users', 'isAdmin');
+
+  if (!hasSnake && hasCamel) {
+    await dataSource.query(
+      `ALTER TABLE users RENAME COLUMN "isAdmin" TO is_admin`,
+    );
+    console.log('[legacy-schema] renamed users."isAdmin" → is_admin');
+    return true;
+  }
+
+  if (hasSnake && hasCamel) {
+    await dataSource.query(
+      `
+      UPDATE users
+      SET is_admin = COALESCE(is_admin, "isAdmin", false)
+      `,
+    );
+    await dataSource.query(`ALTER TABLE users DROP COLUMN IF EXISTS "isAdmin"`);
+    console.log('[legacy-schema] merged users."isAdmin" into is_admin and dropped camelCase column');
+    return true;
+  }
+
+  if (!hasSnake) {
+    await dataSource.query(
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS is_admin boolean NOT NULL DEFAULT false`,
+    );
+    console.log('[legacy-schema] added users.is_admin column');
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Ensure system_config keeps the v1.0.3 snake_case JSON columns that TypeORM
+ * may have also created under camelCase when column names were omitted.
+ */
+export async function alignSystemConfigColumns(dataSource: DataSource): Promise<boolean> {
+  if (!(await tableExists(dataSource, 'system_config'))) {
+    return false;
+  }
+
+  let changed = false;
+
+  const mergeJsonColumn = async (snake: string, camel: string): Promise<void> => {
+    const hasSnake = await columnExists(dataSource, 'system_config', snake);
+    const hasCamel = await columnExists(dataSource, 'system_config', camel);
+
+    if (!hasSnake && hasCamel) {
+      await dataSource.query(
+        `ALTER TABLE system_config RENAME COLUMN "${camel}" TO ${snake}`,
+      );
+      console.log(`[legacy-schema] renamed system_config."${camel}" → ${snake}`);
+      changed = true;
+      return;
+    }
+
+    if (hasSnake && hasCamel) {
+      await dataSource.query(
+        `
+        UPDATE system_config
+        SET ${snake} = COALESCE(${snake}, "${camel}")
+        WHERE ${snake} IS NULL AND "${camel}" IS NOT NULL
+        `,
+      );
+      await dataSource.query(
+        `ALTER TABLE system_config DROP COLUMN IF EXISTS "${camel}"`,
+      );
+      console.log(
+        `[legacy-schema] merged system_config."${camel}" into ${snake} and dropped camelCase column`,
+      );
+      changed = true;
+    }
+  };
+
+  await mergeJsonColumn('smart_routing', 'smartRouting');
+  await mergeJsonColumn('mcp_router', 'mcpRouter');
+  await mergeJsonColumn('modelscope', 'modelscope');
+
+  return changed;
+}
+
+/**
+ * Report how many users (and whether admin) already live in the shared `users`
+ * table. Passwords are bcrypt hashes stored in-place — there is nothing to
+ * "migrate" for admin credentials when reconnecting to a v1.0.3 database.
+ */
+export async function inspectLegacyUsers(dataSource: DataSource): Promise<{
+  existingUserCount: number;
+  adminUserPresent: boolean;
+}> {
+  if (!(await tableExists(dataSource, 'users'))) {
+    return { existingUserCount: 0, adminUserPresent: false };
+  }
+
+  const countRows = await dataSource.query(`SELECT COUNT(*)::int AS count FROM users`);
+  const existingUserCount = Number(countRows?.[0]?.count ?? 0);
+  const adminRows = await dataSource.query(
+    `SELECT 1 FROM users WHERE username = $1 LIMIT 1`,
+    ['admin'],
+  );
+  const adminUserPresent = Array.isArray(adminRows) && adminRows.length > 0;
+
+  if (existingUserCount > 0) {
+    console.log(
+      `[legacy-schema] Reusing ${existingUserCount} existing user(s) from the database` +
+        (adminUserPresent
+          ? ' (including admin). Keep the password you set before the upgrade — ' +
+            'the random password printed during a failed 1.1.x boot only applied to ' +
+            'an empty file-mode install and is NOT written back over this row.'
+          : '.') ,
+    );
+  } else {
+    console.log(
+      '[legacy-schema] users table is empty; a default admin will be created on first boot if needed',
+    );
+  }
+
+  return { existingUserCount, adminUserPresent };
+}
+
+/**
+ * Run all v1.0.x → 1.1.x in-place schema upgrades. Safe to call on every boot.
+ */
+export async function runLegacySchemaMigrations(
+  dataSource: DataSource,
+): Promise<LegacySchemaMigrationResult> {
+  console.log('[legacy-schema] Checking for v1.0.x → 1.1.x upgrades…');
+
+  const userAdminColumnAligned = await alignUserAdminColumn(dataSource);
+  const systemConfigColumnsAligned = await alignSystemConfigColumns(dataSource);
+  const { existingUserCount, adminUserPresent } = await inspectLegacyUsers(dataSource);
+  const serverCopy = await migrateMcpServersTable(dataSource);
+
+  // Count endpoint owner backfill more reliably than driver rowCount
+  let endpointOwnersBackfilled = 0;
+  if (await tableExists(dataSource, 'xiaozhi_endpoints')) {
+    if (!(await columnExists(dataSource, 'xiaozhi_endpoints', 'owner'))) {
+      await dataSource.query(
+        `ALTER TABLE xiaozhi_endpoints ADD COLUMN IF NOT EXISTS owner character varying`,
+      );
+      console.log('[legacy-schema] added xiaozhi_endpoints.owner column');
+    }
+    const pending = await dataSource.query(
+      `
+      SELECT COUNT(*)::int AS count
+      FROM xiaozhi_endpoints
+      WHERE owner IS NULL OR owner = ''
+      `,
+    );
+    endpointOwnersBackfilled = Number(pending?.[0]?.count ?? 0);
+    if (endpointOwnersBackfilled > 0) {
+      await dataSource.query(
+        `
+        UPDATE xiaozhi_endpoints
+        SET owner = $1
+        WHERE owner IS NULL OR owner = ''
+        `,
+        [LEGACY_OWNER],
+      );
+      console.log(
+        `[legacy-schema] backfilled owner on ${endpointOwnersBackfilled} xiaozhi endpoint(s)`,
+      );
+    }
+  }
+
+  const groupOwnersBackfilled = await backfillGroupOwners(dataSource);
+  if (groupOwnersBackfilled > 0) {
+    console.log(`[legacy-schema] backfilled owner on ${groupOwnersBackfilled} group(s)`);
+  }
+
+  const summary: LegacySchemaMigrationResult = {
+    serversCopied: serverCopy.serversCopied,
+    serversSkipped: serverCopy.serversSkipped,
+    endpointOwnersBackfilled,
+    groupOwnersBackfilled,
+    userAdminColumnAligned,
+    systemConfigColumnsAligned,
+    existingUserCount,
+    adminUserPresent,
+  };
+
+  console.log(
+    `[legacy-schema] Done: serversCopied=${summary.serversCopied}, serversSkipped=${summary.serversSkipped}, ` +
+      `endpointOwners=${summary.endpointOwnersBackfilled}, groupOwners=${summary.groupOwnersBackfilled}, ` +
+      `users=${summary.existingUserCount}, adminPresent=${summary.adminUserPresent}`,
+  );
+
+  return summary;
+}

--- a/src/utils/migration.test.ts
+++ b/src/utils/migration.test.ts
@@ -4,11 +4,26 @@ import { jest } from '@jest/globals';
 
 const initializeDatabaseMock = jest.fn(async () => undefined);
 const createQueryBuilderMock = jest.fn();
+const getAppDataSourceMock = jest.fn(() => ({
+  createQueryBuilder: createQueryBuilderMock,
+}));
 jest.mock('../db/connection.js', () => ({
   initializeDatabase: initializeDatabaseMock,
-  getAppDataSource: jest.fn(() => ({
-    createQueryBuilder: createQueryBuilderMock,
-  })),
+  getAppDataSource: getAppDataSourceMock,
+}));
+
+const runLegacySchemaMigrationsMock = jest.fn(async () => ({
+  serversCopied: 0,
+  serversSkipped: 0,
+  endpointOwnersBackfilled: 0,
+  groupOwnersBackfilled: 0,
+  userAdminColumnAligned: false,
+  systemConfigColumnsAligned: false,
+  existingUserCount: 0,
+  adminUserPresent: false,
+}));
+jest.mock('./legacySchemaMigration.js', () => ({
+  runLegacySchemaMigrations: runLegacySchemaMigrationsMock,
 }));
 
 const setDaoFactoryMock = jest.fn();
@@ -191,6 +206,33 @@ describe('initializeDatabaseMode legacy bearer auth migration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockOwnerBackfillUpdates(0);
+    runLegacySchemaMigrationsMock.mockClear();
+    runLegacySchemaMigrationsMock.mockResolvedValue({
+      serversCopied: 0,
+      serversSkipped: 0,
+      endpointOwnersBackfilled: 0,
+      groupOwnersBackfilled: 0,
+      userAdminColumnAligned: false,
+      systemConfigColumnsAligned: false,
+      existingUserCount: 0,
+      adminUserPresent: false,
+    });
+  });
+
+  it('runs v1.0.x schema migration before DAO switch', async () => {
+    userRepoCountMock.mockResolvedValue(1);
+    bearerKeyCountMock.mockResolvedValue(1);
+    systemConfigGetMock.mockResolvedValue({});
+
+    const { initializeDatabaseMode } = await import('./migration.js');
+    const ok = await initializeDatabaseMode();
+
+    expect(ok).toBe(true);
+    expect(initializeDatabaseMock).toHaveBeenCalled();
+    expect(runLegacySchemaMigrationsMock).toHaveBeenCalledTimes(1);
+    expect(runLegacySchemaMigrationsMock.mock.invocationCallOrder[0]).toBeLessThan(
+      setDaoFactoryMock.mock.invocationCallOrder[0],
+    );
   });
 
   it('skips legacy migration when bearerKeys table already has data', async () => {
@@ -205,6 +247,7 @@ describe('initializeDatabaseMode legacy bearer auth migration', () => {
 
     expect(ok).toBe(true);
     expect(initializeDatabaseMock).toHaveBeenCalled();
+    expect(runLegacySchemaMigrationsMock).toHaveBeenCalled();
     expect(loadOriginalSettingsMock).not.toHaveBeenCalled();
     expect(systemConfigGetMock).not.toHaveBeenCalled();
     expect(bearerKeyCreateMock).not.toHaveBeenCalled();

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -436,9 +436,14 @@ export async function initializeDatabaseMode(): Promise<boolean> {
   try {
     console.log('Initializing database mode...');
 
-    // Initialize database connection
+    // Initialize database connection (TypeORM synchronize creates missing 1.1 tables)
     await initializeDatabase();
     console.log('Database connection established');
+
+    // v1.0.x → 1.1.x in-place upgrades (mcp_servers → servers, column renames, owners)
+    // Must run before DAO reads so upgraded installs see their existing data.
+    const { runLegacySchemaMigrations } = await import('./legacySchemaMigration.js');
+    await runLegacySchemaMigrations(getAppDataSource());
 
     // Switch to database factory
     setDaoFactory(DatabaseDaoFactory.getInstance());
@@ -458,7 +463,7 @@ export async function initializeDatabaseMode(): Promise<boolean> {
         throw new Error('Migration failed');
       }
     } else {
-      console.log(`Database already contains ${userCount} users, skipping migration`);
+      console.log(`Database already contains ${userCount} users, skipping file→DB migration`);
 
       // One-time migration for legacy bearer auth config stored inside DB routing settings.
       // If bearerKeys table already has data, do nothing.

--- a/src/utils/smartRouting.ts
+++ b/src/utils/smartRouting.ts
@@ -1,4 +1,5 @@
 import { expandEnvVars } from '../config/index.js';
+import { getDatabaseUrlFromEnv } from '../config/dbEnv.js';
 import {
   getUserConfigOrEmpty,
   mergeSmartRoutingSettings,
@@ -63,7 +64,7 @@ export interface SmartRoutingConfig {
  *
  * Priority order for each setting:
  * 1. Specific environment variables (ENABLE_SMART_ROUTING, SMART_ROUTING_ENABLED, etc.)
- * 2. Generic environment variables (OPENAI_API_KEY, DB_URL, etc.)
+ * 2. Generic environment variables (OPENAI_API_KEY, DB_URL / legacy DATABASE_URL, etc.)
  * 3. Effective settings: systemConfig.smartRouting merged with optional UserConfig overrides
  * 4. Default values
  *
@@ -98,7 +99,8 @@ export async function getSmartRoutingConfig(
     ),
 
     // Database configuration (system/env only — mergeSmartRoutingSettings already forces system dbUrl)
-    dbUrl: getConfigValue([process.env.DB_URL], smartRoutingSettings.dbUrl, '', expandEnvVars),
+    // Prefer DB_URL; fall back to legacy DATABASE_URL for v1.0.3 compose upgrades.
+    dbUrl: getConfigValue([getDatabaseUrlFromEnv()], smartRoutingSettings.dbUrl, '', expandEnvVars),
 
     basePacingDelayMs: getConfigValue<number>(
       [process.env.SMART_ROUTING_BASE_PACING_DELAY_MS],

--- a/src/utils/systemConfigCache.ts
+++ b/src/utils/systemConfigCache.ts
@@ -1,9 +1,9 @@
 import { SystemConfig } from '../types/index.js';
+import { isDatabaseModeEnabled as resolveDatabaseModeEnabled } from '../config/dbEnv.js';
 
 let cachedSystemConfig: SystemConfig | null = null;
 
-export const isDatabaseModeEnabled = (): boolean =>
-  process.env.USE_DB !== undefined ? process.env.USE_DB === 'true' : Boolean(process.env.DB_URL);
+export const isDatabaseModeEnabled = (): boolean => resolveDatabaseModeEnabled();
 
 export const getCachedSystemConfig = (): SystemConfig | null => cachedSystemConfig;
 

--- a/tests/index.boot.test.ts
+++ b/tests/index.boot.test.ts
@@ -74,16 +74,36 @@ describe('index boot', () => {
 
     delete process.env.USE_DB;
     delete process.env.DB_URL;
+    delete process.env.DATABASE_URL;
   });
 
   it('starts the app without waiting for the hosted Redis subscriber to connect', async () => {
     await import('../src/index.js');
-    await Promise.resolve();
-    await Promise.resolve();
+
+    // boot() is async and may await dynamic imports (dbEnv) + hydrate + initialize.
+    // Flush microtasks until start() has run instead of a fixed tick count.
+    for (let i = 0; i < 20 && startMock.mock.calls.length === 0; i += 1) {
+      await Promise.resolve();
+    }
 
     expect(hydrateSystemConfigCacheMock).toHaveBeenCalledTimes(1);
     expect(startHostedEventSubscriberMock).toHaveBeenCalledTimes(1);
     expect(initializeMock).toHaveBeenCalledTimes(1);
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(backfillMissingOwnersInJsonSettingsMock).toHaveBeenCalledTimes(1);
+    expect(initializeDatabaseModeMock).not.toHaveBeenCalled();
+  });
+
+  it('enables database mode when only legacy DATABASE_URL is set', async () => {
+    process.env.DATABASE_URL = 'postgres://xiaozhi:pw@db:5432/xiaozhi_mcphub';
+
+    await import('../src/index.js');
+    for (let i = 0; i < 20 && startMock.mock.calls.length === 0; i += 1) {
+      await Promise.resolve();
+    }
+
+    expect(initializeDatabaseModeMock).toHaveBeenCalledTimes(1);
+    expect(backfillMissingOwnersInJsonSettingsMock).not.toHaveBeenCalled();
     expect(startMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/models/user-default-password.test.ts
+++ b/tests/models/user-default-password.test.ts
@@ -126,11 +126,21 @@ describe('initializeDefaultUser', () => {
   });
 
   it('should not create a user when users already exist', async () => {
-    mockFindAll.mockResolvedValue([{ username: 'existing', password: 'hash', isAdmin: true }]);
+    mockFindAll.mockResolvedValue([{ username: 'admin', password: 'hash', isAdmin: true }]);
 
     await initializeDefaultUser();
 
     expect(mockCreateWithHashedPassword).not.toHaveBeenCalled();
+    expect(loggedMessages()).toContain('reusing existing admin credentials');
+  });
+
+  it('should keep a non-empty store without inventing admin when username admin is absent', async () => {
+    mockFindAll.mockResolvedValue([{ username: 'alice', password: 'hash', isAdmin: false }]);
+
+    await initializeDefaultUser();
+
+    expect(mockCreateWithHashedPassword).not.toHaveBeenCalled();
+    expect(loggedMessages()).toContain('no admin username');
   });
 
   it('should generate different passwords on successive calls (randomness check)', async () => {


### PR DESCRIPTION
## Summary
- Fixes #34: upgrading Docker from **v1.0.3 → 1.1.x** no longer silently drops MCP servers / Xiaozhi endpoints, and no longer confuses users with a newly generated admin password when the old Postgres volume is still present.
- Accept legacy **`DATABASE_URL`** as a deprecated fallback for **`DB_URL`** so old compose files keep database mode.
- On DB boot, **idempotently copy** missing rows from legacy **`mcp_servers` → `servers`**, backfill owners, and align a few v1.0.3 column names (`is_admin`, `smart_routing`, …). Already-upgraded 1.1.2 installs recover on next start if the old table remains.
- Refuse empty DB URLs (no more silent `127.0.0.1:5432`); skip embedding init when no URL is configured.
- Clarify that **admin password lives in `users`** and is reused (not re-migrated / not overwritten). Document the upgrade path.
- Bump version to **1.1.3** for the hotfix release.

## Test plan
- [x] `jest` focused suites: `dbEnv`, `legacySchemaMigration`, `migration`, `connection`, `index.boot`, `user-default-password` (all green)
- [ ] Pull this image/tag on a v1.0.3 `pgdata` volume (or a 1.1.2 volume that still has `mcp_servers`)
- [ ] Confirm logs show `[legacy-schema] Found legacy mcp_servers… copied=…` and `reusing existing admin credentials`
- [ ] Login with **pre-upgrade admin password**; servers + Xiaozhi endpoints visible
- [ ] Compose with only `DATABASE_URL` still enables DB mode (deprecation warning once)
- [ ] No `ECONNREFUSED 127.0.0.1:5432` spam when DB URL is unset and smart routing is off

## Release
After merge to `main`, tag `v1.1.3` to trigger Docker build + GitHub Release workflows.