### PR TITLE
fix: users.username synchronize crash on v1.0.3 upgrade (#34)

### DIFF
--- a/documents/docs/configuration/upgrade-from-v103.md
+++ b/documents/docs/configuration/upgrade-from-v103.md
@@ -63,6 +63,20 @@ SELECT COUNT(*) FROM xiaozhi_endpoints;
 - `mcp_servers` 有数据、`servers` 为空或明显偏少 → 启动后会把缺失行拷进 `servers`。  
 - 小智端点表名未变；连对库后应直接可见，并会把空 `owner` 回填为 `admin`。  
 
+### 若启动报 `column "username" … contains null values`
+
+1.1.3 早期在 TypeORM `synchronize` 时，可能把 v1.0.3 的无长度 `varchar` 误重建成 `varchar(255) NOT NULL`，对已有 admin 行会失败。  
+**1.1.4+** 已去掉该 length 漂移，并在 synchronize 前做安全预对齐。
+
+若你仍卡在 1.1.3，可先手工确认（一般无需改数据——你的 `select * from users` 里 username 已有值）：
+
+```sql
+SELECT username, length(password) FROM users;
+-- username 不应为 NULL
+```
+
+然后直接拉 **≥1.1.4** 镜像重启即可；不要 `DROP` users。
+
 ### Admin 密码会不会丢？要不要迁？
 
 **不用单独迁 admin 密码。** v1.0.3 的账号就在同一 Postgres 的 **`users`** 表里（bcrypt 哈希，表名未改）。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huangjunsen0406/xiaozhi-mcphub",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "MCPHub enhanced with Xiaozhi AI platform integration - \u4e3a\u5c0f\u667aAI\u5e73\u53f0\u4f18\u5316\u7684MCP\u5de5\u5177\u6865\u63a5\u7cfb\u7edf",
   "main": "dist/index.js",
   "type": "module",

--- a/src/db/connection.test.ts
+++ b/src/db/connection.test.ts
@@ -51,6 +51,11 @@ jest.mock('./types/postgresVectorType.js', () => ({
   registerPostgresVectorType: jest.fn(),
 }));
 
+const prepareLegacySchemaBeforeSynchronizeMock = jest.fn(async () => undefined);
+jest.mock('../utils/legacySchemaMigration.js', () => ({
+  prepareLegacySchemaBeforeSynchronize: prepareLegacySchemaBeforeSynchronizeMock,
+}));
+
 import {
   checkDatabaseHealth,
   closeDatabase,
@@ -66,11 +71,23 @@ const registerPostgresVectorTypeMock = jest.mocked(registerPostgresVectorType);
 describe('database connection recovery', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    prepareLegacySchemaBeforeSynchronizeMock.mockClear();
+    prepareLegacySchemaBeforeSynchronizeMock.mockResolvedValue(undefined);
   });
 
   afterEach(async () => {
     stopHealthCheck();
     await closeDatabase();
+  });
+
+  it('runs legacy pre-synchronize safety before first initialize', async () => {
+    await initializeDatabase();
+    expect(prepareLegacySchemaBeforeSynchronizeMock).toHaveBeenCalledWith(
+      'postgresql://mcphub:test@postgres:5432/mcphub',
+    );
+    // First DataSource is the pre-sync helper only when real code runs; here the
+    // production initialize path must still call the main DataSource.initialize.
+    expect(dataSources.some((ds) => ds.initialize.mock.calls.length > 0)).toBe(true);
   });
 
   it('reuses the existing configuration when recovering an uninitialized or disconnected driver', async () => {

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -209,6 +209,16 @@ const performDatabaseInitialization = async (): Promise<DataSource> => {
     appDataSource = await updateDataSourceConfig();
 
     if (!appDataSource.isInitialized) {
+      // v1.0.3 DBs can break TypeORM synchronize (e.g. varchar length drift →
+      // DROP+ADD NOT NULL on users.username). Patch legacy shapes first.
+      const dbUrl = ((appDataSource.options as { url?: string }).url || '').trim();
+      if (dbUrl) {
+        const { prepareLegacySchemaBeforeSynchronize } = await import(
+          '../utils/legacySchemaMigration.js'
+        );
+        await prepareLegacySchemaBeforeSynchronize(dbUrl);
+      }
+
       console.log('Initializing database connection...');
       // Register the vector type with TypeORM
       await appDataSource.initialize();

--- a/src/db/entities/Group.ts
+++ b/src/db/entities/Group.ts
@@ -17,13 +17,16 @@ export class Group {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ type: 'varchar', length: 255 })
+  // No length on name/owner: match v1.0.3 unlimited varchar so synchronize does
+  // not DROP+ADD NOT NULL on existing group rows.
+  @Column({ type: 'varchar' })
   name: string;
 
   @Column({ type: 'text', nullable: true })
   description?: string;
 
-  @Column({ type: 'simple-json' })
+  // nullable keeps v1.0.3 rows valid; app code still treats missing as [].
+  @Column({ type: 'simple-json', nullable: true })
   servers: Array<
     | string
     | {
@@ -35,7 +38,7 @@ export class Group {
       }
   >;
 
-  @Column({ type: 'varchar', length: 255, nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   owner?: string;
 
   @CreateDateColumn({ name: 'created_at', type: 'timestamp' })

--- a/src/db/entities/User.ts
+++ b/src/db/entities/User.ts
@@ -14,23 +14,26 @@ export class User {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ type: 'varchar', length: 255, unique: true })
+  // No length: v1.0.3 created unlimited varchar. TypeORM synchronize treats a
+  // length change as DROP+ADD NOT NULL, which fails on existing admin rows
+  // ("column username contains null values" during the rebuild).
+  @Column({ type: 'varchar', unique: true })
   username: string;
 
-  @Column({ type: 'varchar', length: 255 })
+  @Column({ type: 'varchar' })
   password: string;
 
   // Keep explicit snake_case column name so v1.0.3 databases (is_admin) keep working.
   @Column({ type: 'boolean', default: false, name: 'is_admin' })
   isAdmin: boolean;
 
-  @Column({ type: 'varchar', length: 255, nullable: true, unique: true })
+  @Column({ type: 'varchar', nullable: true, unique: true })
   email: string | null;
 
   @Column({ type: 'boolean', default: false, name: 'email_verified' })
   emailVerified: boolean;
 
-  @Column({ type: 'varchar', length: 255, nullable: true, unique: true, name: 'sso_user_id' })
+  @Column({ type: 'varchar', nullable: true, unique: true, name: 'sso_user_id' })
   ssoUserId: string | null;
 
   @CreateDateColumn({ name: 'created_at', type: 'timestamp' })

--- a/src/utils/legacySchemaMigration.test.ts
+++ b/src/utils/legacySchemaMigration.test.ts
@@ -27,6 +27,61 @@ describe('legacySchemaMigration', () => {
     jest.clearAllMocks();
   });
 
+  it('prepareUsersTableForSync adds missing 1.1 columns without touching username', async () => {
+    const executed: string[] = [];
+    const dataSource = createDataSourceMock(async (sql: string, params?: unknown[]) => {
+      executed.push(sql.replace(/\s+/g, ' ').trim());
+      const normalized = sql.replace(/\s+/g, ' ').toLowerCase();
+      if (normalized.includes('information_schema.tables')) {
+        return [{ exists: true }];
+      }
+      if (normalized.includes('information_schema.columns')) {
+        const col = params?.[1];
+        // Core v1.0.3 columns present; 1.1 extras missing; is_admin present
+        if (col === 'username' || col === 'password' || col === 'is_admin') {
+          return [{ exists: true }];
+        }
+        return [{ exists: false }];
+      }
+      if (normalized.includes('username is null')) {
+        return [{ count: 0 }];
+      }
+      return [];
+    });
+
+    const { prepareUsersTableForSync } = await import('./legacySchemaMigration.js');
+    const changed = await prepareUsersTableForSync(dataSource as any);
+    expect(changed).toBe(true);
+
+    const joined = executed.join('\n').toLowerCase();
+    expect(joined).toContain('add column if not exists email');
+    expect(joined).toContain('add column if not exists email_verified');
+    expect(joined).toContain('add column if not exists sso_user_id');
+    // Must never drop/recreate username
+    expect(joined).not.toMatch(/drop column.*username|add column.*username/);
+  });
+
+  it('prepareUsersTableForSync throws when username has nulls', async () => {
+    const dataSource = createDataSourceMock(async (sql: string, params?: unknown[]) => {
+      const normalized = sql.replace(/\s+/g, ' ').toLowerCase();
+      if (normalized.includes('information_schema.tables')) {
+        return [{ exists: true }];
+      }
+      if (normalized.includes('information_schema.columns')) {
+        const col = params?.[1];
+        if (col === 'username' || col === 'password') return [{ exists: true }];
+        return [{ exists: false }];
+      }
+      if (normalized.includes('username is null')) {
+        return [{ count: 1 }];
+      }
+      return [];
+    });
+
+    const { prepareUsersTableForSync } = await import('./legacySchemaMigration.js');
+    await expect(prepareUsersTableForSync(dataSource as any)).rejects.toThrow(/NULL row/);
+  });
+
   it('copies mcp_servers rows into servers via repository when missing', async () => {
     const dataSource = createDataSourceMock(async (sql: string) => {
       const normalized = sql.replace(/\s+/g, ' ').toLowerCase();

--- a/src/utils/legacySchemaMigration.ts
+++ b/src/utils/legacySchemaMigration.ts
@@ -308,6 +308,139 @@ export async function alignUserAdminColumn(dataSource: DataSource): Promise<bool
 }
 
 /**
+ * Make legacy `users` safe for TypeORM synchronize before it runs.
+ *
+ * 1.1.x entities added optional email / email_verified / sso_user_id. If those
+ * columns are missing, synchronize would ADD them — fine for nullable ones, but
+ * a botched length rebuild of username/password previously used DROP+ADD NOT NULL
+ * and failed with "column username contains null values" on existing admin rows.
+ *
+ * This helper:
+ * - adds missing nullable 1.1 columns with safe defaults (never rebuilds username)
+ * - never drops or recreates username/password
+ *
+ * Must run with synchronize:false (or before the first synchronize on a fresh
+ * DataSource that still has the legacy column shapes).
+ */
+export async function prepareUsersTableForSync(dataSource: DataSource): Promise<boolean> {
+  if (!(await tableExists(dataSource, 'users'))) {
+    return false;
+  }
+
+  let changed = false;
+
+  // Ensure core identity columns exist (they should on every real install).
+  // Do NOT touch length / NOT NULL — leave whatever v1.0.3 created.
+  if (!(await columnExists(dataSource, 'users', 'username'))) {
+    throw new Error(
+      '[legacy-schema] users.username is missing; cannot upgrade this database automatically',
+    );
+  }
+  if (!(await columnExists(dataSource, 'users', 'password'))) {
+    throw new Error(
+      '[legacy-schema] users.password is missing; cannot upgrade this database automatically',
+    );
+  }
+
+  // Refuse to proceed if username already has nulls (would break any NOT NULL rebuild).
+  const nullUsernames = await dataSource.query(
+    `SELECT COUNT(*)::int AS count FROM users WHERE username IS NULL`,
+  );
+  const nullCount = Number(nullUsernames?.[0]?.count ?? 0);
+  if (nullCount > 0) {
+    throw new Error(
+      `[legacy-schema] users.username has ${nullCount} NULL row(s); fix or delete them before upgrading`,
+    );
+  }
+
+  if (!(await columnExists(dataSource, 'users', 'email'))) {
+    await dataSource.query(
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS email character varying`,
+    );
+    console.log('[legacy-schema] added users.email');
+    changed = true;
+  }
+
+  if (!(await columnExists(dataSource, 'users', 'email_verified'))) {
+    await dataSource.query(
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified boolean NOT NULL DEFAULT false`,
+    );
+    console.log('[legacy-schema] added users.email_verified');
+    changed = true;
+  }
+
+  if (!(await columnExists(dataSource, 'users', 'sso_user_id'))) {
+    await dataSource.query(
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS sso_user_id character varying`,
+    );
+    console.log('[legacy-schema] added users.sso_user_id');
+    changed = true;
+  }
+
+  // is_admin alignment is shared with the post-sync path
+  if (await alignUserAdminColumn(dataSource)) {
+    changed = true;
+  }
+
+  return changed;
+}
+
+/**
+ * Pre-synchronize repairs that must run BEFORE TypeORM synchronize, because
+ * synchronize can DROP+ADD columns when metadata (e.g. varchar length) drifts
+ * from the live schema — fatal on tables that already have rows.
+ *
+ * Connects with synchronize:false, patches legacy shapes, then disconnects so
+ * the normal initialize path can open with synchronize:true safely.
+ */
+export async function prepareLegacySchemaBeforeSynchronize(
+  databaseUrl: string,
+): Promise<void> {
+  if (!databaseUrl) {
+    return;
+  }
+
+  console.log('[legacy-schema] Pre-synchronize safety pass on legacy tables…');
+
+  const preSync = new DataSource({
+    type: 'postgres',
+    url: databaseUrl,
+    synchronize: false,
+    entities: [],
+  });
+
+  try {
+    await preSync.initialize();
+
+    // uuid-ossp may be needed later; cheap and idempotent
+    try {
+      await preSync.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+    } catch (err: any) {
+      console.warn('[legacy-schema] uuid-ossp extension note:', err?.message || err);
+    }
+
+    await prepareUsersTableForSync(preSync);
+
+    // groups.servers was nullable json in v1.0.3; ensure column exists without
+    // forcing NOT NULL so synchronize will not rebuild it over existing rows.
+    if (await tableExists(preSync, 'groups')) {
+      if (!(await columnExists(preSync, 'groups', 'owner'))) {
+        await preSync.query(
+          `ALTER TABLE groups ADD COLUMN IF NOT EXISTS owner character varying`,
+        );
+        console.log('[legacy-schema] added groups.owner before synchronize');
+      }
+    }
+
+    console.log('[legacy-schema] Pre-synchronize safety pass complete');
+  } finally {
+    if (preSync.isInitialized) {
+      await preSync.destroy();
+    }
+  }
+}
+
+/**
  * Ensure system_config keeps the v1.0.3 snake_case JSON columns that TypeORM
  * may have also created under camelCase when column names were omitted.
  */


### PR DESCRIPTION
## Summary
- Follow-up to #35 / v1.1.3: reporter hit `QueryFailedError: column "username" of relation "users" contains null values` while initializing DB mode on a real v1.0.3 `users` row (`admin` present, non-null).
- Root cause: TypeORM `synchronize` treats unlimited `varchar` → `varchar(255)` as **DROP + ADD NOT NULL**, which fails on tables that already have rows.
- Fix: remove conflicting `length` on legacy User/Group columns; run a **pre-synchronize** safety pass that only *adds* missing 1.1 columns (`email`, etc.) and never rebuilds `username`/`password`.
- Bump to **1.1.4**.

## Test plan
- [x] Unit tests: `legacySchemaMigration` + `connection` (pre-sync hook)
- [ ] On a v1.0.3 `pgdata` volume: boot 1.1.4, confirm no username error, see `[legacy-schema] Pre-synchronize…` then `mcp_servers` copy
- [ ] Login with pre-upgrade admin password; servers restored

Closes the remaining blocker on #34 after v1.1.3.