### PR TITLE
fix: restore system_config.modelscope after 1.1.4 self-merge drop (#34)

### DIFF
--- a/documents/docs/configuration/upgrade-from-v103.md
+++ b/documents/docs/configuration/upgrade-from-v103.md
@@ -75,7 +75,20 @@ SELECT username, length(password) FROM users;
 -- username 不应为 NULL
 ```
 
-然后直接拉 **≥1.1.4** 镜像重启即可；不要 `DROP` users。
+然后直接拉 **≥1.1.5** 镜像重启即可；不要 `DROP` users。
+
+### 若启动报 `column SystemConfig.modelscope does not exist`
+
+1.1.4 有一处 bug：把 `modelscope` 当成「驼峰/蛇形同名」做合并时，把**唯一**的 `modelscope` 列 DROP 掉了。  
+**1.1.5+** 会跳过同名合并，并在启动时 `ADD COLUMN IF NOT EXISTS modelscope` 自动补回。
+
+直接拉新镜像重启即可，一般无需手工 SQL。若要手动确认：
+
+```sql
+SELECT column_name FROM information_schema.columns
+WHERE table_name = 'system_config' ORDER BY 1;
+-- 应包含 modelscope、smart_routing、mcp_router 等
+```
 
 ### Admin 密码会不会丢？要不要迁？
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huangjunsen0406/xiaozhi-mcphub",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "MCPHub enhanced with Xiaozhi AI platform integration - \u4e3a\u5c0f\u667aAI\u5e73\u53f0\u4f18\u5316\u7684MCP\u5de5\u5177\u6865\u63a5\u7cfb\u7edf",
   "main": "dist/index.js",
   "type": "module",

--- a/src/utils/legacySchemaMigration.test.ts
+++ b/src/utils/legacySchemaMigration.test.ts
@@ -82,6 +82,79 @@ describe('legacySchemaMigration', () => {
     await expect(prepareUsersTableForSync(dataSource as any)).rejects.toThrow(/NULL row/);
   });
 
+  it('alignSystemConfigColumns does not drop modelscope when snake === camel', async () => {
+    const executed: string[] = [];
+    const dataSource = createDataSourceMock(async (sql: string, params?: unknown[]) => {
+      executed.push(sql.replace(/\s+/g, ' ').trim());
+      const normalized = sql.replace(/\s+/g, ' ').toLowerCase();
+      if (normalized.includes('information_schema.tables')) {
+        return [{ exists: true }];
+      }
+      if (normalized.includes('information_schema.columns')) {
+        const col = params?.[1];
+        // modelscope present; camelCase twins for smart_routing / mcp_router absent
+        if (col === 'modelscope' || col === 'smart_routing' || col === 'mcp_router') {
+          return [{ exists: true }];
+        }
+        // optional 1.1 columns already present so ensure* is a no-op
+        if (
+          typeof col === 'string' &&
+          [
+            'routing',
+            'install',
+            'toolResultCompression',
+            'email',
+            'oauth',
+            'oauthServer',
+            'auth',
+            'discovery',
+            'activityLog',
+            'nameSeparator',
+            'enableSessionRebuild',
+          ].includes(col)
+        ) {
+          return [{ exists: true }];
+        }
+        return [{ exists: false }];
+      }
+      return [];
+    });
+
+    const { alignSystemConfigColumns } = await import('./legacySchemaMigration.js');
+    await alignSystemConfigColumns(dataSource as any);
+
+    const joined = executed.join('\n').toLowerCase();
+    // Must never DROP modelscope (the self-merge bug)
+    expect(joined).not.toMatch(/drop column.*modelscope/);
+    // Should not attempt a no-op self-rename either
+    expect(joined).not.toMatch(/rename column "modelscope"/);
+  });
+
+  it('alignSystemConfigColumns recreates missing modelscope after 1.1.4 damage', async () => {
+    const executed: string[] = [];
+    const dataSource = createDataSourceMock(async (sql: string, params?: unknown[]) => {
+      executed.push(sql.replace(/\s+/g, ' ').trim());
+      const normalized = sql.replace(/\s+/g, ' ').toLowerCase();
+      if (normalized.includes('information_schema.tables')) {
+        return [{ exists: true }];
+      }
+      if (normalized.includes('information_schema.columns')) {
+        const col = params?.[1];
+        // modelscope missing (dropped by 1.1.4); other required cols present
+        if (col === 'modelscope') return [{ exists: false }];
+        return [{ exists: true }];
+      }
+      return [];
+    });
+
+    const { alignSystemConfigColumns } = await import('./legacySchemaMigration.js');
+    const changed = await alignSystemConfigColumns(dataSource as any);
+    expect(changed).toBe(true);
+    expect(
+      executed.some((s) => /add column if not exists modelscope/i.test(s)),
+    ).toBe(true);
+  });
+
   it('copies mcp_servers rows into servers via repository when missing', async () => {
     const dataSource = createDataSourceMock(async (sql: string) => {
       const normalized = sql.replace(/\s+/g, ' ').toLowerCase();

--- a/src/utils/legacySchemaMigration.ts
+++ b/src/utils/legacySchemaMigration.ts
@@ -443,6 +443,11 @@ export async function prepareLegacySchemaBeforeSynchronize(
 /**
  * Ensure system_config keeps the v1.0.3 snake_case JSON columns that TypeORM
  * may have also created under camelCase when column names were omitted.
+ *
+ * IMPORTANT: only merge when snake !== camel. Calling merge with the same name
+ * (e.g. modelscope/modelscope) treats one real column as both sides, then
+ * DROP COLUMN "modelscope" deletes the only copy — which is exactly the
+ * "column SystemConfig.modelscope does not exist" failure seen on 1.1.4.
  */
 export async function alignSystemConfigColumns(dataSource: DataSource): Promise<boolean> {
   if (!(await tableExists(dataSource, 'system_config'))) {
@@ -452,6 +457,11 @@ export async function alignSystemConfigColumns(dataSource: DataSource): Promise<
   let changed = false;
 
   const mergeJsonColumn = async (snake: string, camel: string): Promise<void> => {
+    // Same physical name → nothing to rename/merge; never DROP it.
+    if (snake === camel) {
+      return;
+    }
+
     const hasSnake = await columnExists(dataSource, 'system_config', snake);
     const hasCamel = await columnExists(dataSource, 'system_config', camel);
 
@@ -482,11 +492,68 @@ export async function alignSystemConfigColumns(dataSource: DataSource): Promise<
     }
   };
 
+  // Only pairs where the DB name differs from a possible TypeORM default.
   await mergeJsonColumn('smart_routing', 'smartRouting');
   await mergeJsonColumn('mcp_router', 'mcpRouter');
-  await mergeJsonColumn('modelscope', 'modelscope');
+  // modelscope is already the entity column name (name: 'modelscope') — do not
+  // "merge" it with itself. Just ensure it exists (recovery for 1.1.4 damage).
+  if (await ensureSystemConfigColumn(dataSource, 'modelscope', 'text')) {
+    changed = true;
+  }
+
+  // Other 1.1 columns the entity selects; ADD IF NOT EXISTS so a partial
+  // upgrade / botched drop cannot leave SELECTs broken.
+  const optionalJsonColumns = [
+    'routing',
+    'install',
+    'smart_routing',
+    'toolResultCompression',
+    'mcp_router',
+    'email',
+    'oauth',
+    'oauthServer',
+    'auth',
+    'discovery',
+    'activityLog',
+  ];
+  for (const col of optionalJsonColumns) {
+    if (await ensureSystemConfigColumn(dataSource, col, 'text')) {
+      changed = true;
+    }
+  }
+  if (await ensureSystemConfigColumn(dataSource, 'nameSeparator', 'character varying(10)')) {
+    changed = true;
+  }
+  if (await ensureSystemConfigColumn(dataSource, 'enableSessionRebuild', 'boolean')) {
+    changed = true;
+  }
 
   return changed;
+}
+
+/**
+ * Add a missing system_config column (nullable). Idempotent.
+ * Used both for normal upgrades and to repair columns dropped by the
+ * modelscope self-merge bug in 1.1.4.
+ */
+export async function ensureSystemConfigColumn(
+  dataSource: DataSource,
+  columnName: string,
+  pgType: string,
+): Promise<boolean> {
+  if (!(await tableExists(dataSource, 'system_config'))) {
+    return false;
+  }
+  if (await columnExists(dataSource, 'system_config', columnName)) {
+    return false;
+  }
+  // Quote identifiers that are mixed-case so Postgres preserves them.
+  const quoted = /[A-Z]/.test(columnName) ? `"${columnName}"` : columnName;
+  await dataSource.query(
+    `ALTER TABLE system_config ADD COLUMN IF NOT EXISTS ${quoted} ${pgType}`,
+  );
+  console.log(`[legacy-schema] added system_config.${columnName} (${pgType})`);
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Follow-up on #34 after 1.1.4: boot gets past username sync and copies/skips `mcp_servers`, then dies with `column SystemConfig.modelscope does not exist`.
- Root cause: `alignSystemConfigColumns` called `mergeJsonColumn('modelscope', 'modelscope')`. With one physical column, the “both sides exist” path ran `DROP COLUMN "modelscope"` and deleted the only copy.
- Fix: never merge when snake === camel; `ADD COLUMN IF NOT EXISTS` for `modelscope` and other `system_config` fields the entity selects (repairs already-damaged DBs).
- Bump to **1.1.5**.

## Test plan
- [x] Unit tests cover “do not DROP modelscope” and “recreate missing modelscope”
- [ ] On reporter’s volume (or any DB that ran 1.1.4 once): boot 1.1.5, confirm system config loads, servers still present, admin login works

Continues #34 recovery path.